### PR TITLE
Add Support for Snippets that can be injected into the prompts.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+
+.PHONY: run
+run:
+	docker build -t yakgpt .
+	docker compose up -d

--- a/components/ChatDisplay.tsx
+++ b/components/ChatDisplay.tsx
@@ -11,6 +11,7 @@ import NewChat from "./NewChat";
 import MuHeader from "./MuHeader";
 
 import ChatMessage from "./ChatMessage";
+import UIController from "@/components/UIController";
 import { IconChevronsDown } from "@tabler/icons-react";
 import { useRouter } from "next/router";
 import { setActiveChatId } from "@/stores/ChatActions";
@@ -186,7 +187,9 @@ const ChatDisplay = () => {
           <IconChevronsDown size={px("1.1rem")} stroke={1.5} />
         </ActionIcon>
       )}
+          <UIController />
     </div>
+
   );
 };
 

--- a/components/SnippetDisplay.tsx
+++ b/components/SnippetDisplay.tsx
@@ -1,0 +1,88 @@
+
+import { createStyles, MantineTheme } from "@mantine/core";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import { useChatStore } from "@/stores/ChatStore";
+import { Snippet } from "@/stores/Snippet";
+import { Button, TextInput, Paper } from "@mantine/core";
+const useStyles = createStyles((theme: MantineTheme) => ({
+  snippetContainer: {
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    alignItems: "stretch",
+    padding: theme.spacing.md,
+    borderRadius: theme.radius.sm,
+    backgroundColor: theme.colors.gray[0],
+    [`@media (min-width: ${theme.breakpoints.md})`]: {
+      padding: theme.spacing.lg,
+    },
+  },
+  snippet: {
+    width: "100%",
+    minHeight: "200px",
+    borderRadius: theme.radius.sm,
+    padding: theme.spacing.md,
+    fontSize: theme.fontSizes.md,
+    wordWrap: "break-word",
+    backgroundColor: theme.colors.white,
+    border: `1px solid ${theme.colors.gray[4]}`,
+    marginTop: theme.spacing.md,
+  },
+}));
+
+const SnippetDisplay = () => {
+  const { classes } = useStyles();
+  const router = useRouter();
+  const snippetId = router.query.snippetId as string | undefined;
+  const snippets = useChatStore((state) => state.snippets);
+  const activeSnippet = snippets.find((snippet: Snippet) => snippet.id === snippetId);
+  const [snippetContent, setSnippetContent] = useState(activeSnippet ? activeSnippet.content : "");
+  const [snippetIdInput, setSnippetIdInput] = useState(snippetId ? snippetId : "");
+
+  useEffect(() => {
+    if (snippetId) {
+      setSnippetIdInput(snippetId);
+      const snippet = snippets.find((snippet: Snippet) => snippet.id === snippetId);
+      if (snippet) {
+        setSnippetContent(snippet.content);
+      }
+    }
+  }, [snippetId, snippets]);
+
+  const handleSave = () => {
+    const snippetToSave = snippets.find((snippet: Snippet) => snippet.id === snippetIdInput);
+    if (snippetToSave) {
+      // Update existing snippet
+      snippetToSave.content = snippetContent;
+    } else {
+      // Create new snippet
+      const newSnippet: Snippet = {
+        id: snippetIdInput,
+        content: snippetContent,
+      };
+      snippets.push(newSnippet);
+    }
+  };
+
+  return (
+    <div>
+      <TextInput
+        value={snippetIdInput}
+        onChange={(e) => setSnippetIdInput(e.target.value)}
+        placeholder="Enter a snippet ID..."
+        style={{ marginBottom: '10px' }}
+      />
+      <TextInput
+        className={classes.snippet}
+        value={snippetContent}
+        onChange={(e) => setSnippetContent(e.target.value)}
+        placeholder="Enter a snippet..."
+        style={{ marginBottom: '10px' }}
+      />
+      <Button color="blue" onClick={handleSave}>Save</Button>
+    </div>
+  );
+};
+
+export default SnippetDisplay;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+
+version: '3.8'
+services:
+  yakgpt:
+    image: yakgpt:latest
+    ports:
+      - 3000:3000
+    environment:
+      - NODE_ENV=production

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -13,7 +13,6 @@ import { useChatStore } from "@/stores/ChatStore";
 
 import Nav from "@/components/Nav";
 import { useEffect, useState } from "react";
-import UIController from "@/components/UIController";
 import { setColorScheme } from "@/stores/ChatActions";
 import AudioPlayer from "@/components/AudioPlayer";
 
@@ -109,8 +108,6 @@ export default function App(props: AppProps) {
           >
             <div style={{ position: "relative", height: "100%" }}>
               <Component {...pageProps} />
-
-              {apiKey && <UIController />}
             </div>
             {playerMode && <AudioPlayer />}
           </AppShell>

--- a/pages/snippets/[snippetId].tsx
+++ b/pages/snippets/[snippetId].tsx
@@ -1,0 +1,5 @@
+import SnippetDisplay from "@/components/SnippetDisplay";
+
+export default function Home() {
+  return <SnippetDisplay />;
+}

--- a/pages/snippets/index.tsx
+++ b/pages/snippets/index.tsx
@@ -1,0 +1,5 @@
+import SnippetDisplay from "@/components/SnippetDisplay";
+
+export default function Index() {
+  return <SnippetDisplay />;
+}

--- a/stores/ChatStore.ts
+++ b/stores/ChatStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { Message } from "./Message";
 import { persist } from "zustand/middleware";
 import { Chat } from "./Chat";
+import { Snippet } from "./Snippet";
 import { SpeechRecognizer } from "microsoft-cognitiveservices-speech-sdk";
 import type { AudioChunk } from "./PlayerActions";
 
@@ -96,6 +97,9 @@ export interface ChatState {
   defaultSettings: SettingsForm;
   navOpened: boolean;
 
+  snippets: Snippet[];
+  activeSnippetId: string | undefined;
+
   pushToTalkMode: boolean;
   recorder: MediaRecorder | undefined;
   recognizer: SpeechRecognizer | undefined;
@@ -139,6 +143,11 @@ export const initialState = {
   playerMode: false,
   pushToTalkMode: false,
   editingMessage: undefined,
+
+  snippets: [
+    { id: "exampleSnippet", content: "When you respond, mention that a snippet was used"}
+  ],
+  activeSnippetId: undefined,
 
   recorder: undefined,
   recognizer: undefined,

--- a/stores/Message.ts
+++ b/stores/Message.ts
@@ -1,4 +1,5 @@
 import encoder from "@nem035/gpt-3-encoder";
+import { Snippet } from "./Snippet";
 
 export const countTokens = (text: string) => encoder.encode(text).length;
 
@@ -15,9 +16,39 @@ function estimateTokens(content: string): number {
   return Math.ceil(words * (100 / 75));
 }
 
+export function messageContent(message: Message, snippets: Snippet[]) {
+  if (message.role === "system") {
+    return message.content;
+  }
+  // Find all snippet entry codes by searching for [[snippetname]] pattern
+  // only search for snippets that we know exist in the snippets array
+  const snippetNames = snippets.map(snippet => snippet.id);
+  const snippetRegex = new RegExp(
+    `\\[\\[(${snippetNames.join("|")})\\]\\]`,
+    "g"
+  );
+  const matches = message.content.match(snippetRegex);
+  if (matches) {
+    // Replace all snippet entry codes with the actual snippet
+    let ret = message.content;
+    for (const match of matches) {
+      const snippetName = match.slice(2, -2);
+      const snippet = snippets.find(snippet => snippet.id === snippetName);
+      if (snippet) {
+        ret = ret.replace(match, snippet.content);
+      }
+    }
+    return ret;
+  } else {
+    return message.content;
+  }
+}
+
+
 // Truncate messages
 export function truncateMessages(
   messages: Message[],
+  snippets: Snippet[],
   modelMaxTokens: number,
   userMaxTokens: number
 ): Message[] {
@@ -35,7 +66,7 @@ export function truncateMessages(
   let startIdx = 0;
 
   if (messages[0].role === "system") {
-    accumulatedTokens = estimateTokens(messages[0].content);
+    accumulatedTokens = estimateTokens(messageContent(messages[0], snippets));
     ret.push(messages[0]);
     startIdx = 1;
   }
@@ -43,7 +74,7 @@ export function truncateMessages(
   // Try to truncate messages as is
   for (let i = messages.length - 1; i >= startIdx; i--) {
     const message = messages[i];
-    const tokens = estimateTokens(message.content);
+    const tokens = estimateTokens(messageContent(message, snippets));
     if (accumulatedTokens + tokens > targetTokens) {
       break;
     }

--- a/stores/OpenAI.ts
+++ b/stores/OpenAI.ts
@@ -1,6 +1,7 @@
 import { IncomingMessage } from "http";
 import https from "https";
-import { Message, truncateMessages, countTokens } from "./Message";
+import { Message, truncateMessages, countTokens, messageContent } from "./Message";
+import { Snippet } from "./Snippet";
 import { getModelInfo } from "./Model";
 import axios from "axios";
 
@@ -114,6 +115,7 @@ const paramKeys = [
 
 export async function streamCompletion(
   messages: Message[],
+  snippets: Snippet[],
   params: ChatCompletionParams,
   apiKey: string,
   abortController?: AbortController,
@@ -126,6 +128,7 @@ export async function streamCompletion(
   // Truncate messages to fit within maxTokens parameter
   const submitMessages = truncateMessages(
     messages,
+    snippets,
     modelInfo.maxTokens,
     params.max_tokens
   );
@@ -135,7 +138,7 @@ export async function streamCompletion(
   );
 
   const payload = JSON.stringify({
-    messages: submitMessages.map(({ role, content }) => ({ role, content })),
+    messages: submitMessages.map((message: Message) => ({ role: message.role, content: messageContent(message, snippets) })),
     stream: true,
     ...{
       ...submitParams,

--- a/stores/Snippet.ts
+++ b/stores/Snippet.ts
@@ -1,0 +1,4 @@
+export interface Snippet {
+  id: string;
+  content: string;
+}

--- a/stores/SubmitMessage.ts
+++ b/stores/SubmitMessage.ts
@@ -106,6 +106,7 @@ export const submitMessage = async (message: Message) => {
   // ASSISTANT REQUEST
   await streamCompletion(
     chat.messages,
+    get().snippets,
     settings,
     apiKey,
     abortController,
@@ -187,6 +188,7 @@ export const submitMessage = async (message: Message) => {
 
       await streamCompletion(
         [msg, ...chat.messages.slice(1)],
+        get().snippets,
         settings,
         apiKey,
         undefined,


### PR DESCRIPTION
This is a first draft of a change to add support for Snippets to the UX.

As implemented, snippets can be inserted into prompts in the format [[snippetId]], and there is some basic editing.

THIS IS A DRAFT

The UI for the snippet editing is very bad.

I think a better UX would be to have special HTML pill type characters to hide the snippets, rather than typing a [[snippetId]] in directly.

There is some concern because the message content currently retains the format character.  This means that if you edit the snippet and re-run, the history will be changed.  Probably a small concern, but I think a better UX would embed a HTML pill element, which hid the snippet text as it was when the chat was first run.

I have never really done anything in react, so most of this was written by GPT-4 using cursor.sh